### PR TITLE
configurable ajax urls

### DIFF
--- a/couchlog/config.py
+++ b/couchlog/config.py
@@ -23,6 +23,7 @@ _DEFAULT_DISPLAY_COLS = ["id", "archived?", "date", "", "message", "user", "url"
 COUCHLOG_TABLE_CONFIG = getattr(settings, "COUCHLOG_TABLE_CONFIG", _DEFAULT_TABLE_CONFIG)
 COUCHLOG_DISPLAY_COLS = getattr(settings, "COUCHLOG_DISPLAY_COLS", _DEFAULT_DISPLAY_COLS)
 COUCHLOG_RECORD_WRAPPER = getattr(settings, "COUCHLOG_RECORD_WRAPPER", None)
+COUCHLOG_SINGLE_URL_BASE = getattr(settings, "COUCHLOG_SINGLE_URL_BASE", '/couchlog/ajax/single/')
 
 # We don't bother shipping with these libraries, but if you want to import them from your own 
 # servers just add these configuration params to localsettings.

--- a/couchlog/static/couchlog/js/logtable.js
+++ b/couchlog/static/couchlog/js/logtable.js
@@ -1,6 +1,6 @@
 function init_log_table(filter, id_column, archived_column, date_column,
                         message_column, actions_column, email_column, no_cols,
-                        show, ajax_url) 
+                        show, ajax_url, single_url_base)
 {
     var not_sortable = [];
     for (i=0; i<no_cols; i++) {
@@ -58,7 +58,7 @@ function init_log_table(filter, id_column, archived_column, date_column,
                         } else {
                             display = oObj.aData[message_column];
                         }
-                        return '<a href="/couchlog/ajax/single/' + oObj.aData[0] + '" onclick="$(\'#modal-placeholder\').jqmShow($(this)); return false;"  class="logview">' + display +'</a>';
+                        return '<a href="' + single_url_base + oObj.aData[0] + '" onclick="$(\'#modal-placeholder\').jqmShow($(this)); return false;"  class="logview">' + display +'</a>';
                     },
                     "aTargets": [message_column]
                 }, 

--- a/couchlog/templates/couchlog/dashboard.html
+++ b/couchlog/templates/couchlog/dashboard.html
@@ -27,9 +27,11 @@
         var email_column = {{ config.email_column }};
         var no_cols = {{ config.no_cols }};
         var ajax_url = "{% url couchlog_paging %}";
+        var single_url_base = "{{ single_url_base }}";
+
         init_log_table(filter, id_column, archived_column, date_column,
                        message_column, actions_column, email_column, no_cols,
-                       show, ajax_url);
+                       show, ajax_url, single_url_base);
     } );
     </script>
     <script type="text/javascript">

--- a/couchlog/views.py
+++ b/couchlog/views.py
@@ -68,6 +68,7 @@ def dashboard(request):
                                "support_email": config.SUPPORT_EMAIL,
                                "config": config.COUCHLOG_TABLE_CONFIG,
                                "display_cols": config.COUCHLOG_DISPLAY_COLS,
+                               "single_url_base": config.COUCHLOG_SINGLE_URL_BASE,
                                "couchlog_config": config},
                                context_instance=RequestContext(request))
 


### PR DESCRIPTION
ignoring the fact that this whole library is incredibly ugly... this was the quickest way to work around some cross-site protection issues involving jqmodal and https. essentially will allow us to specify:

`COUCHLOG_SINGLE_URL_BASE = 'https://www.commcarehq.org/couchlog/ajax/single/'`

in settings and then the modals will finally work. this isn't great but i don't want to invest a larger amount of time figuring out something smarter for what is purely a dev facing feature
