### PR TITLE
new urls module

### DIFF
--- a/couchlog/urls.py
+++ b/couchlog/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('',
     url(r'^$', 'couchlog.views.dashboard', name='couchlog_home'),


### PR DESCRIPTION
django.conf.urls.defaults is deprecated and removed in Django 1.6