### PR TITLE
always redirect to built in couclog view, remove COUCHLOG_SINGLE_URL_BASE

### DIFF
--- a/couchlog/config.py
+++ b/couchlog/config.py
@@ -23,7 +23,6 @@ _DEFAULT_DISPLAY_COLS = ["id", "archived?", "date", "", "message", "user", "url"
 COUCHLOG_TABLE_CONFIG = getattr(settings, "COUCHLOG_TABLE_CONFIG", _DEFAULT_TABLE_CONFIG)
 COUCHLOG_DISPLAY_COLS = getattr(settings, "COUCHLOG_DISPLAY_COLS", _DEFAULT_DISPLAY_COLS)
 COUCHLOG_RECORD_WRAPPER = getattr(settings, "COUCHLOG_RECORD_WRAPPER", None)
-COUCHLOG_SINGLE_URL_BASE = getattr(settings, "COUCHLOG_SINGLE_URL_BASE", '/couchlog/ajax/single/')
 
 # We don't bother shipping with these libraries, but if you want to import them from your own 
 # servers just add these configuration params to localsettings.

--- a/couchlog/views.py
+++ b/couchlog/views.py
@@ -1,3 +1,4 @@
+import uuid
 from django.conf import settings
 from dimagi.utils.web import get_url_base
 from django.shortcuts import render_to_response
@@ -84,13 +85,14 @@ def dashboard(request):
                 ExceptionRecord.get_db().bulk_delete(rec_json_list)
                 messages.success(request, "%s records successfully deleted." % len(records))
     
+    single_url_base = reverse('couchlog_single', args=['throwaway']).replace('throwaway/', '')
     return render_to_response('couchlog/dashboard.html',
                               {"show" : show, "count": True,
                                "lucene_enabled": config.LUCENE_ENABLED,
                                "support_email": config.SUPPORT_EMAIL,
                                "config": config.COUCHLOG_TABLE_CONFIG,
                                "display_cols": config.COUCHLOG_DISPLAY_COLS,
-                               "single_url_base": config.COUCHLOG_SINGLE_URL_BASE,
+                               "single_url_base": single_url_base,
                                "couchlog_config": config},
                                context_instance=RequestContext(request))
 


### PR DESCRIPTION
this was never getting overridden and was redirecting to the ajax view instead of the one with the full stack trace.

@snopoke / anyone